### PR TITLE
Gems that do not demand any config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,4 +83,6 @@ group :test do
   # For web application testing [https://github.com/SeleniumHQ/selenium]
   gem 'selenium-webdriver', '~> 4.4'
 
+  # For Selenium framework [https://github.com/titusfortner/webdrivers]
+  gem 'webdrivers', '~> 5.0', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -232,6 +236,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdrivers (~> 5.0)
 
 RUBY VERSION
    ruby 3.1.2p20


### PR DESCRIPTION
# Task:

Add gems without config

# Change proposed in this pull request:

Add Gemfile and Gemfile.lock 'cause were added following gems:

1. gem 'image_processing'
2. gem 'active_storage_validations'
3. gem 'factory_bot_rails'
4. gem 'pry'
5. gem 'faker'
6. gem 'web-console' (by default)
7. gem 'selenium-webdriver'
8. gem 'webdrivers'