### PR TITLE
Add controllers and views for Event model

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -15,7 +15,7 @@ class CategoriesController < ApplicationController
   def update
     if CategoriesServices::UpdateCategoryService.new(category: @category, category_params:,
                                                      user: current_user).call
-      redirect_to categories_path, notice: t('flash.notice.update')
+      redirect_to categories_path, notice: t('flash.notice.category.update')
     else
       render :new, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class CategoriesController < ApplicationController
     @category = Category.new(category_params)
     if CategoriesServices::CreateCategoryService.new(category: @category, category_params:,
                                                      user: current_user).call
-      redirect_to categories_path, notice: t('flash.notice.create')
+      redirect_to categories_path, notice: t('flash.notice.category.create')
     else
       render :new, status: :unprocessable_entity
     end
@@ -37,7 +37,7 @@ class CategoriesController < ApplicationController
 
   def destroy
     if CategoriesServices::DeleteCategoryService.new(category: @category, user: current_user).call
-      redirect_to categories_path, notice: t('flash.notice.delete')
+      redirect_to categories_path, notice: t('flash.notice.category.delete')
     else
       redirect_to categories_path, status: :unprocessable_entity
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class EventsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_event, only: %i[show edit update destroy]
+
+  def index
+    @events = current_user.events.page(params[:page]).per(params[:per_page])
+  end
+
+  def show; end
+
+  def new
+    @event = Event.new
+  end
+
+  def create
+    @event = current_user.events.build(event_params)
+    if @event.save
+      redirect_to events_path, notice: t('flash.notice.event.create')
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @event.update(event_params)
+      redirect_to events_path, notice: t('flash.notice.event.update')
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @event.delete
+      redirect_to events_path, notice: t('flash.notice.event.delete')
+    else
+      redirect_to events_path, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(:name, :description, :event_date, :reminder_on, :category_id)
+  end
+
+  def set_event
+    @event = Event.find(params[:id])
+  end
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module EventsHelper
+  def event_numb(index)
+    page = params[:page].to_i.positive? ? params[:page].to_i : 1
+    per_page = params[:per_page].to_i.positive? ? params[:per_page].to_i : 20
+    calc_event_num(page, per_page, index)
+  end
+
+  def calc_event_num(page, per_page, index)
+    (page - 1) * per_page + index + 1
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
+  paginates_per 20
+
   belongs_to :category, dependent: :destroy
   belongs_to :user, dependent: :destroy
 
@@ -10,6 +12,7 @@ class Event < ApplicationRecord
   validate :reminder_date_validity, if: :reminder_on_changed?
   validate :event_date_validity
 
+  default_scope { order(event_date: :asc) }
   scope :future, -> { where(event_date: DateTime.now.end_of_day..) }
   scope :today, -> { where(event_date: DateTime.now.beginning_of_day..DateTime.now.end_of_day) }
 
@@ -19,15 +22,15 @@ class Event < ApplicationRecord
     return if reminder_on.blank?
 
     if reminder_on.past?
-      errors.add(:reminder_on, "can't be in the past")
+      errors.add(:reminder_on, :past)
     elsif reminder_on >= event_date
-      errors.add(:reminder_on, "can't be equal or greater than event date")
+      errors.add(:reminder_on, :too_late)
     end
   end
 
   def event_date_validity
     return if event_date&.future?
 
-    errors.add(:event_date, "can't be in the past")
+    errors.add(:event_date, :past)
   end
 end

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,6 @@
+<div class="row d-flex justify-content-center align-items-center p-4">
+  <div class="col-5">
+    <h1 class="text-center mb-4"><%= t('event.edit') %></h1>
+    <%= render partial: "events/partials/form", locals: { event: @event } %>
+  </div>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,12 @@
+<div class="container p-4 min-vh-100 mb-4">
+  <h1 class="text-center mb-4"><%= t('event.events') %></h1>
+  <div class="container mb-4">
+    <div id="events"><%= render partial: 'events/partials/events', locals: { events: @events } %></div>
+    <%= link_to t('btn.add'), new_event_path, class: "btn btn-primary mb-4" %>
+    <div class="mb-4 col-sm-1">
+      <%= select_tag :per_page, options_for_select([5, 10, 20, 30], params[:per_page]), 
+          class:"form-select" %>
+    </div>
+    <%= paginate @events %>
+  </div>
+</div>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,6 @@
+<div class="row d-flex justify-content-center align-items-center p-4">
+  <div class="col-5">
+    <h1 class="text-center mb-4"><%= t('event.create') %></h1>
+    <%= render partial: 'events/partials/form', locals: { event: @event } %>
+  </div>
+</div>

--- a/app/views/events/partials/_event.html.erb
+++ b/app/views/events/partials/_event.html.erb
@@ -1,0 +1,8 @@
+<tr class="text-center">
+  <th scope="row">
+    <%= link_to event_numb(index), event_path(event.id, locale: I18n.locale) %>
+  </th>
+  <td><%= event.name %></td>
+  <td><%= event.category.name %></td>
+  <td><%= l(event.event_date, format: :default) %></td>
+</tr>

--- a/app/views/events/partials/_events.html.erb
+++ b/app/views/events/partials/_events.html.erb
@@ -1,0 +1,15 @@
+<% if events.empty? %>
+  <h2 class="text-center p-4"><%= t('event.no_events') %></h2>
+<% else %>
+  <table class="table table-borderless table-hover">
+    <tr class="text-center">
+      <th scope="col">#</th>
+      <th scope="col"><%= t('event.name') %></th>
+      <th scope="col"><%= t('event.category') %></th>
+      <th scope="col"><%= t('event.time') %></th>
+    </tr>
+    <% events.each_with_index do |event, index| %>
+      <%= render partial: 'events/partials/event', locals: { event: event, index: index } %>
+    <% end %>
+  </table>
+<% end %>

--- a/app/views/events/partials/_form.html.erb
+++ b/app/views/events/partials/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with model: event do |f| %>
+  <%= render partial: 'layouts/error', locals: { model: event, attribute: :name} %>
+  <div class="field mb-4">
+    <%= f.text_field :name, class: "form-control", placeholder: t('event.name') %>
+  </div>
+  <div class="field mb-4">
+    <%= f.text_field :description, class: "form-control", placeholder: t('event.description') %>
+  </div>
+  <%= render partial: 'layouts/error', locals: { model: event, attribute: :event_date} %>
+  <div class="field mb-4">
+    <%= f.datetime_field :event_date, class: "form-control", placeholder: 'Event date' %>
+  </div>
+  <%= render partial: 'layouts/error', locals: { model: event, attribute: :reminder_on} %>
+  <div class="field mb-4">
+    <%= f.datetime_field :reminder_on, class: "form-control", placeholder: 'Reminder on' %>
+  </div>
+  <%= render partial: 'layouts/error', locals: { model: event, attribute: :category} %>
+  <div class="field mb-4">
+    <%= f.collection_select :category_id, current_user.categories, :id, :name,
+                            { prompt: t('event.category'), selected: "", disabled: "" },
+                            { class: "form-control",
+                              placeholder: "Category select" } %>
+  </div>
+  <p>
+    <%= f.submit t('btn.create'), class: "btn btn-primary" %>
+  </p>
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -13,8 +13,10 @@
         </div>
       <% end %>
       <div class="col-sm-6 btns d-flex align-items-center">
-        <%= link_to t('btn.edit'), edit_event_path(@event.id), class: "btn btn-primary me-auto px-4" %>
-        <%= button_to t('btn.delete'), event_path(@event.id), method: :delete, class: "btn btn-danger" %>
+        <%= link_to t('btn.edit'), edit_event_path(@event.id, locale: I18n.locale), 
+           class: "btn btn-primary me-auto px-4" %>
+        <%= button_to t('btn.delete'), event_path(@event.id, locale: I18n.locale), 
+           method: :delete, class: "btn btn-danger" %>
       </div>
     </div>
     <div class="col-sm-6 p-4">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,25 @@
+<div class="container">
+  <div class="row ">
+    <div class="col-sm-6 p-4">
+      <h2><%= @event.name %></h2>
+      <p><%= @event.description %></p>
+      <div class="d-flex align-items-center mb-4">
+        <i class="me-auto"><%= l(@event.event_date, format: :default) %></i>
+        <b><%= @event.category.name %></b>
+      </div>
+      <% if @event.reminder_on %>
+        <div class="mb-4">
+          <%= t('event.reminder') %><%= l(@event.reminder_on, format: :default) %>
+        </div>
+      <% end %>
+      <div class="col-sm-6 btns d-flex align-items-center">
+        <%= link_to t('btn.edit'), edit_event_path(@event.id), class: "btn btn-primary me-auto px-4" %>
+        <%= button_to t('btn.delete'), event_path(@event.id), method: :delete, class: "btn btn-danger" %>
+      </div>
+    </div>
+    <div class="col-sm-6 p-4">
+      <h2><%= t('event.weather') %></h2>
+      <p><%= t('event.info') %></p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     root 'home#index'
     devise_for :users, path: '', controllers: { registrations: 'users/registrations' }
     resources :categories
+    resources :events
   end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -10,7 +10,7 @@ users = 5.times.map do |index|
   end
 end
 
-10.times do
+100.times do
   Event.create!(
     name: Faker::Lorem.word,
     event_date: Faker::Date.between(from: DateTime.now.tomorrow, to: 1.year.from_now),

--- a/my/locales/en.yml
+++ b/my/locales/en.yml
@@ -1,5 +1,20 @@
 en:
 
+  activerecord:
+    errors:
+      models:
+        event:
+          attributes:
+            event_date: 
+              past: "can't be in the past"
+            reminder_on: 
+              past: "can't be in the past"
+              too_late: "can't be equal or greater than event date"
+
+  time:
+    formats:
+      default: "%Y-%m-%d %H:%M"
+
   nav:
     company: "Company"
     en: "EN"
@@ -48,7 +63,7 @@ en:
     change_btn: "Change"
     instruction_btn: "Send instructions"
     confirm_link: "Confirm my account"
-  
+
   btn:
     delete: "Delete"
     create: "Create"
@@ -64,13 +79,43 @@ en:
 
   flash:
     notice: 
-      create: 'Category successfully created'
-      delete: 'Category successfully deleted'
-      update: 'Category updated successfully'
-      error: 'You already have this category'
+      category:
+        create: 'Category successfully created'
+        delete: 'Category successfully deleted'
+        update: 'Category updated successfully'
+      event:
+        create: 'Event successfully created'
+        delete: 'Event successfully deleted'
+        update: 'Event updated successfully'
   
   pagination:
     next: "Next"
     last: "Last"
     first: "First"
     previous: "Previous"
+
+  event:
+    name: "Name"
+    category: "Category"
+    time: "Time"
+    edit: "Edit event"
+    create: "Create event"
+    events: "Events"
+    name: "Name"
+    description: "Description"
+    category: "Category"
+    reminder: "Reminder at"
+    weather: "Weather in this day"
+    info: "Information is not available"
+    no_events: "No Events"
+
+  btn:
+    add: "Add"
+    edit: "Edit"
+    create: "Create"
+    delete: "Delete"
+      
+  pagination:
+    next: "Next"
+    last: "Last"
+    first: "First"

--- a/my/locales/ru.yml
+++ b/my/locales/ru.yml
@@ -114,7 +114,7 @@ ru:
     time: "Время"
     edit: "Изменение"
     create: "Создание события"
-    events: "Events"
+    events: "События"
     description: "Описание"
     category: "Категория"
     reminder: "Напомнить в"
@@ -127,12 +127,6 @@ ru:
     edit: "Изменить"
     create: "Создать"
     delete: "Удалить"
-  
-  flash:
-    notice: 
-      create: 'Событие успешно создано'
-      delete: 'Событие успешно удалено'
-      update: 'Событие успешно обновлено'
 
   pagination:
     next: "Следующая"

--- a/my/locales/ru.yml
+++ b/my/locales/ru.yml
@@ -10,6 +10,10 @@ ru:
         current_password: "Текущий пароль"
       category:
         name: "Категория"
+      event:
+        name: "Название"
+        event_date: "Дата события"
+        reminder_on: "Дата напоминания"
     errors:
       models:
         user:
@@ -20,6 +24,27 @@ ru:
           attributes:
             name: 
               blank: "не может быть пустой"
+        event:
+          attributes:
+            name: 
+              blank: "не может быть пустым"
+            event_date: 
+              blank: "не может быть пустой"
+              past: "не может быть в прошлом"
+            reminder_on: 
+              past: "не может быть в прошлом"
+              too_late: "не может быть равной или больше даты события"
+
+  time:
+    formats:
+      default: "%Y-%m-%d %H:%M"
+  
+  nav:
+    company: "Компания"
+    en: "АНГ"
+    ru: "РУС"
+    categories: "Категории"
+    language: "Язык"
 
   user:
     sign_up: "Зареги-ся"
@@ -41,13 +66,6 @@ ru:
     today_events: "Количество событий сегодня: %{count}"
     start: "Сначала войдите в систему или зарегистрируйтесь"
     welcome: "Добро пожаловать, %{user}"
-
-  nav:
-    company: "Компания"
-    en: "АНГ"
-    ru: "РУС"
-    categories: "Категории"
-    language: "Язык"
 
   devise:
     resend_confirm: "Отправить повторно инструкцию по подтверждению"
@@ -89,7 +107,33 @@ ru:
       delete: 'Категория успешно удалена'
       update: 'Категория успешно обновлена'
       error: 'У вас уже есть эта категория'
+
+  event:
+    name: "Название"
+    category: "Категория"
+    time: "Время"
+    edit: "Изменение"
+    create: "Создание события"
+    events: "Events"
+    description: "Описание"
+    category: "Категория"
+    reminder: "Напомнить в"
+    weather: "Погода в этот день"
+    info: "Информация недоступна"
+    no_events: "Нет событий"
+
+  btn:
+    add: "Добавить"
+    edit: "Изменить"
+    create: "Создать"
+    delete: "Удалить"
   
+  flash:
+    notice: 
+      create: 'Событие успешно создано'
+      delete: 'Событие успешно удалено'
+      update: 'Событие успешно обновлено'
+
   pagination:
     next: "Следующая"
     last: "Последняя"

--- a/spec/controllers/events/events_controller_create_spec.rb
+++ b/spec/controllers/events/events_controller_create_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventsController, type: :controller do
+  describe 'POST /events/new' do
+    subject(:create_event) do
+      post :create,
+           params: { event: { name: category.name, event_date: DateTime.now.tomorrow, category_id: category.id } }
+    end
+
+    let(:user) { create(:user) }
+    let(:category) { create(:category) }
+
+    describe 'when user is authenticated' do
+      before { sign_in(user) }
+
+      it 'save event in the database' do
+        expect { create_event }.to change(Event, :count).from(0).to(1)
+      end
+
+      it 'redirect to events_path' do
+        create_event
+        expect(response).to redirect_to(events_path)
+      end
+
+      it 'set a flash message' do
+        create_event
+        expect(flash[:notice]).to eq('Event successfully created')
+      end
+    end
+
+    describe 'when user is no authenticated' do
+      it 'return status 302' do
+        create_event
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirect to sign in page' do
+        create_event
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it 'not save event in the database' do
+        expect { create_event }.not_to change(Event, :count).from(0)
+      end
+    end
+  end
+end

--- a/spec/controllers/events/events_controller_destroy_spec.rb
+++ b/spec/controllers/events/events_controller_destroy_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventsController, type: :controller do
+  let(:user) { create(:user) }
+
+  describe 'DELETE /events/:id' do
+    subject(:delete_event) { delete :destroy, params: { id: Event.first.id } }
+
+    describe 'when user is authenticated' do
+      before do
+        sign_in(user)
+        create(:event, user:)
+      end
+
+      it 'delete event in the database' do
+        expect { delete_event }.to change(Event, :count).from(1).to(0)
+      end
+
+      it 'redirect to events_path' do
+        delete_event
+        expect(response).to redirect_to(events_path)
+      end
+
+      it 'sets a flash notice message' do
+        delete_event
+        expect(flash[:notice]).to match('Event successfully deleted')
+      end
+    end
+
+    describe 'when user is not authenticated' do
+      before { create(:event) }
+
+      it 'not delete event in the database' do
+        expect { delete_event }.not_to change(Event, :count).from(1)
+      end
+
+      it 'return status 302' do
+        delete_event
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirect to sign in page' do
+        delete_event
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/events/events_controller_edit_spec.rb
+++ b/spec/controllers/events/events_controller_edit_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventsController, type: :controller do
+  let(:user) { create(:user) }
+
+  describe 'PATCH /events/:id' do
+    subject(:edit_event) { patch :update, params: { id: event.id, event: { name: 'NewName' } } }
+
+    let(:event) { create(:event, user:) }
+
+    describe 'when user is authenticated' do
+      before do
+        sign_in(user)
+        edit_event
+      end
+
+      it 'return status 302' do
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirect to events_path' do
+        expect(response).to redirect_to(events_path)
+      end
+
+      it 'set a flash message' do
+        expect(flash[:notice]).to eq('Event updated successfully')
+      end
+
+      it 'update event name' do
+        expect(event.reload.name).to eq('NewName')
+      end
+    end
+
+    describe 'when user is not authenticated' do
+      before { edit_event }
+
+      it 'return status 302' do
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirect to sign in page' do
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it 'not update event name' do
+        expect(event.reload.name).not_to eq('NewName')
+      end
+    end
+  end
+end

--- a/spec/controllers/events/events_controller_index_spec.rb
+++ b/spec/controllers/events/events_controller_index_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe EventsController, type: :controller do
+  let(:user) { create(:user) }
+  let(:category) { create(:category) }
+
+  describe 'GET #index' do
+    let(:events) { create_list(:event, 5, user:, category:) }
+
+    before { get :index }
+
+    describe 'when user is authenticated' do
+      before do
+        sign_in(user)
+        get :index
+      end
+
+      it 'return status 200' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'renders index template' do
+        expect(response).to render_template('index')
+      end
+
+      it 'assigns @events' do
+        expect(assigns(:events)).to match_array(events)
+      end
+    end
+
+    describe 'when user in not authenticated' do
+      it 'return status 302' do
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirect to sign in page' do
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/events/events_controller_show_spec.rb
+++ b/spec/controllers/events/events_controller_show_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventsController, type: :controller do
+  let(:user) { create(:user) }
+
+  describe 'GET /events/:id' do
+    subject(:show_event) { get :show, params: { id: event.id } }
+
+    let(:event) { create(:event) }
+
+    describe 'when user is authenticated' do
+      before do
+        sign_in(user)
+        show_event
+      end
+
+      it 'return status 200' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'renders index template' do
+        expect(response).to render_template('show')
+      end
+
+      it 'assigns @event' do
+        expect(assigns(:event)).to eq(event)
+      end
+    end
+
+    describe 'when user in not authenticated' do
+      before { show_event }
+
+      it 'return status 302' do
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirect to sign in page' do
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/features/events/event_create_spec.rb
+++ b/spec/features/events/event_create_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Event create', type: :feature do
+  let(:user) { create(:user) }
+  let!(:category) { create(:category) }
+  let(:event) { build(:event) }
+
+  describe 'when user is authenticated' do
+    before do
+      create(:user_category, user:, category:)
+      login_as(user)
+      visit new_event_path
+    end
+
+    describe 'create event' do
+      before do
+        fill_in 'Name', with: event.name
+        fill_in 'Event date', with: event.event_date
+        select category.name, from: 'Category select'
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content('Event successfully created') }
+      it { expect(page).to have_content(event.name) }
+      it { expect(page).to have_content(category.name) }
+    end
+
+    describe 'name of event is empty' do
+      before do
+        fill_in 'Event date', with: event.event_date
+        select category.name, from: 'Category select'
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Name can't be blank") }
+    end
+
+    describe 'event date is empty' do
+      before do
+        fill_in 'Name', with: event.name
+        select category.name, from: 'Category select'
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Event date can't be blank") }
+    end
+
+    describe 'event date is in the past' do
+      before do
+        fill_in 'Event date', with: DateTime.now.yesterday
+        fill_in 'Name', with: event.name
+        select category.name, from: 'Category select'
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Event date can't be in the past") }
+    end
+
+    describe 'reminder_on is in the past' do
+      before do
+        fill_in 'Event date', with: DateTime.now.tomorrow
+        fill_in 'Reminder on', with: DateTime.now.yesterday
+        fill_in 'Name', with: event.name
+        select category.name, from: 'Category select'
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Reminder on can't be in the past") }
+    end
+
+    describe 'reminder_on is greater than event_date' do
+      before do
+        fill_in 'Event date', with: DateTime.now.tomorrow
+        fill_in 'Reminder on', with: DateTime.now.tomorrow + 1.minute
+        fill_in 'Name', with: event.name
+        select category.name, from: 'Category select'
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Reminder on can't be equal or greater than event date") }
+    end
+
+    describe 'reminder_on is equal to event_date' do
+      before do
+        fill_in 'Event date', with: DateTime.now.tomorrow
+        fill_in 'Reminder on', with: DateTime.now.tomorrow
+        fill_in 'Name', with: event.name
+        select category.name, from: 'Category select'
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Reminder on can't be equal or greater than event date") }
+    end
+
+    describe 'category is empty' do
+      before do
+        fill_in 'Event date', with: DateTime.now.tomorrow + 1.day
+        fill_in 'Reminder on', with: DateTime.now.tomorrow
+        fill_in 'Name', with: event.name
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content('Category must exist') }
+    end
+  end
+
+  describe 'when user is not authenticated' do
+    before do
+      create(:user_category, user:, category:)
+      visit new_event_path
+    end
+
+    it { expect(page).to have_no_content('Event successfully created') }
+    it { expect(page).to have_no_content(event.name) }
+    it { expect(page).to have_no_content(category.name) }
+  end
+end

--- a/spec/features/events/event_delete_spec.rb
+++ b/spec/features/events/event_delete_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Events#delete', type: :feature do
+  describe 'delete event' do
+    let(:user) { create(:user) }
+
+    describe 'when user is authenticated' do
+      before do
+        login_as(user)
+        create(:event, user:)
+        visit event_path(Event.first.id, locale: I18n.locale)
+        click_button 'Delete'
+      end
+
+      it { expect(page).to have_content('Event successfully deleted') }
+    end
+
+    describe 'when user is not authenticated' do
+      before do
+        create(:event, user:)
+        visit event_path(Event.first.id, locale: I18n.locale)
+      end
+
+      it { expect(page).to have_no_content('Event successfully deleted') }
+    end
+  end
+end

--- a/spec/features/events/event_edit_spec.rb
+++ b/spec/features/events/event_edit_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Event#edit', type: :feature do
+  let(:user) { create(:user) }
+  let!(:category) { create(:category) }
+
+  let!(:event) { create(:event, user:, category:) }
+
+  describe 'when user is authenticated' do
+    before do
+      create(:user_category, user:, category:)
+      login_as(user)
+      visit edit_event_path(event.id, locale: I18n.locale)
+    end
+
+    describe 'edit event' do
+      before do
+        fill_in 'Name', with: 'NewName'
+        select category.name, from: 'Category select'
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content('Event updated successfully') }
+    end
+
+    describe 'when name is empty' do
+      before do
+        fill_in 'Name', with: nil
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Name can't be blank") }
+    end
+
+    describe 'when event date is empty' do
+      before do
+        fill_in 'Event date', with: nil
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Event date can't be blank") }
+    end
+
+    describe 'when event date is in the past' do
+      before do
+        fill_in 'Event date', with: DateTime.now.yesterday
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Event date can't be in the past") }
+    end
+
+    describe 'when reminder_on is in the past' do
+      before do
+        fill_in 'Reminder on', with: DateTime.now.yesterday
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Reminder on can't be in the past") }
+    end
+
+    describe 'when reminder_on is greater than event_date' do
+      before do
+        fill_in 'Event date', with: DateTime.now.tomorrow
+        fill_in 'Reminder on', with: DateTime.now.tomorrow + 1.minute
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Reminder on can't be equal or greater than event date") }
+    end
+
+    describe 'when reminder_on is equal to event_date' do
+      before do
+        fill_in 'Event date', with: DateTime.now.tomorrow
+        fill_in 'Reminder on', with: DateTime.now.tomorrow
+        click_button 'Create'
+      end
+
+      it { expect(page).to have_content("Reminder on can't be equal or greater than event date") }
+    end
+  end
+
+  describe 'when user is not authenticated' do
+    before do
+      create(:user_category, user:, category:)
+      visit edit_event_path(event.id, locale: I18n.locale)
+    end
+
+    it { expect(page).to have_no_content('Event successfully updated') }
+  end
+end

--- a/spec/features/events/event_index_spec.rb
+++ b/spec/features/events/event_index_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Event#index', type: :feature do
+  describe 'index event' do
+    let(:user) { create(:user) }
+    let(:category) { create(:category) }
+
+    describe 'when user is authenticated' do
+      let!(:events) { create_list(:event, 5, user:, category:) }
+
+      before do
+        login_as(user)
+        visit events_path
+      end
+
+      it { expect(page).to have_content('Events') }
+      it { expect(page).to have_link('Add') }
+
+      it 'include user events' do
+        events.each do |event|
+          expect(page).to have_content(event.name)
+        end
+      end
+    end
+
+    describe 'when user is not authenticated' do
+      before { visit events_path }
+
+      it { expect(page).to have_no_content('Events') }
+    end
+  end
+end

--- a/spec/features/events/event_show_spec.rb
+++ b/spec/features/events/event_show_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Event#show', type: :feature do
+  describe 'show event' do
+    let(:user) { create(:user) }
+
+    describe 'when user is authenticated' do
+      before do
+        login_as(user)
+        create(:event)
+        visit event_path(Event.first.id, locale: I18n.locale)
+      end
+
+      it { expect(page).to have_button('Delete') }
+      it { expect(page).to have_link('Edit') }
+    end
+
+    describe 'when user is not authenticated' do
+      before do
+        create(:event)
+        visit event_path(Event.first.id, locale: I18n.locale)
+      end
+
+      it { expect(page).to have_no_content('Event') }
+    end
+  end
+end

--- a/spec/routings/events_routing_spec.rb
+++ b/spec/routings/events_routing_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe 'Events routes path', type: :routing do
+  let(:event) { create(:event, user:, category:) }
+  let(:user) { create(:user) }
+  let(:category) { create(:category) }
+
+  it 'routes Events#index' do
+    expect(get('/events')).to route_to(controller: 'events', action: 'index', locale: I18n.default_locale)
+  end
+
+  it 'routes Events#create' do
+    expect(post('/events')).to route_to(controller: 'events', action: 'create', locale: I18n.default_locale)
+  end
+
+  it 'routes Events#show' do
+    expect(get("/events/#{event.id}")).to route_to(controller: 'events', locale: I18n.default_locale,
+                                                   action: 'show', id: event.id.to_s)
+  end
+
+  it 'routes Events#destroy' do
+    expect(delete("/events/#{event.id}")).to route_to(controller: 'events', locale: I18n.default_locale,
+                                                      action: 'destroy', id: event.id.to_s)
+  end
+
+  it 'routes Events#update' do
+    expect(patch("/events/#{event.id}")).to route_to(controller: 'events', locale: I18n.default_locale,
+                                                     action: 'update', id: event.id.to_s)
+  end
+end

--- a/spec/views/events/edit.html.erb_spec.rb
+++ b/spec/views/events/edit.html.erb_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'events/edit', type: :view do
+  let(:event) { build(:event) }
+  let(:user) { create(:user) }
+
+  before do
+    sign_in(user)
+    assign(:event, event)
+    render template: 'events/edit'
+  end
+
+  it 'field event name' do
+    expect(rendered).to include(CGI.escapeHTML(event.name))
+  end
+
+  it 'submit button' do
+    expect(rendered).to have_xpath '//input[contains(@class, btn)]'
+  end
+end

--- a/spec/views/events/index.html.erb_spec.rb
+++ b/spec/views/events/index.html.erb_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'events/index', type: :view do
+  let(:events) do
+    Kaminari.paginate_array(create_list(:event, 21, user:, category:)).page(1)
+  end
+  let(:category) { create(:category, :work) }
+  let(:user) { create(:user) }
+
+  before do
+    sign_in(user)
+    assign(:events, events)
+    render template: 'events/index'
+  end
+
+  describe 'when more than 20 events' do
+    it { expect(rendered).to have_content(t('event.events')) }
+    it { expect(rendered).to have_xpath '//a[contains(text(), page-link)]' }
+  end
+end

--- a/spec/views/events/new.html.erb_spec.rb
+++ b/spec/views/events/new.html.erb_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'events/new', type: :view do
+  let(:event) { build(:event) }
+  let(:user) { create(:user) }
+
+  before do
+    sign_in(user)
+    assign(:event, event)
+    render template: 'events/new'
+  end
+
+  it 'has field name' do
+    expect(rendered).to include(CGI.escapeHTML(event.name))
+  end
+
+  it 'submit button' do
+    expect(rendered).to have_xpath '//input[contains(@class, btn)]'
+  end
+end

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'events/show', type: :view do
+  let(:event) { create(:event, user:) }
+  let(:user) { create(:user) }
+
+  before do
+    sign_in(user)
+    assign(:event, event)
+    render template: 'events/show'
+  end
+
+  it 'has field name' do
+    expect(rendered).to include(CGI.escapeHTML(event.name))
+  end
+
+  describe 'buttons' do
+    it { expect(rendered).to have_xpath '//button[contains(@class, btn)]' }
+    it { expect(rendered).to have_xpath '//a[contains(@class, btn)]' }
+  end
+end


### PR DESCRIPTION
## Task:
Add controllers and views to Event model

## Change proposed in this pull request:

1. Add controllers to Event model
2. Add views to EventsController
3. Add tests to Events:
    - controller
    - view
    - routing
    - feature
5. Pages:

   - events list page
    
    ![events_1](https://github.com/The7Fame/trainee-planner/assets/96648793/fe053ec5-5929-4276-b193-e92a5ea19dbc)
    
    ![events_2](https://github.com/The7Fame/trainee-planner/assets/96648793/0aa6cc68-6f63-450e-a282-3ff103751694)

    - create event page
    
    ![create_page](https://github.com/The7Fame/trainee-planner/assets/96648793/5ae355dd-8dfa-4676-9340-2a9eb47c696b)

    - edit event page

    ![edit_page](https://github.com/The7Fame/trainee-planner/assets/96648793/b40cf476-a1c3-4dcc-9899-52281220c285)

    - show event page

    ![event](https://github.com/The7Fame/trainee-planner/assets/96648793/e6a76eef-a335-4f28-999f-c6bac44db89b)
